### PR TITLE
fix: ES5 compatibility (for build)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.3' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 1 # Increment this number if you need to re-download cached gems
 
@@ -40,7 +40,7 @@ jobs:
           find: "YYYY.MM.DD"
           replace: "${{ steps.tag.outputs.version }}"
           regex: false
-          
+
       - name: Build site (production)
         if: github.ref == 'refs/heads/main'
         env:

--- a/_includes/head-home-script.html
+++ b/_includes/head-home-script.html
@@ -27,17 +27,17 @@
     aboutElement.style.display = "block";
 
     // do the scroll if directed
-    if (event?.type == "wheel") {
+    if (event != null && event.type == "wheel") {
       window.scrollBy(0, event.deltaY);
-    };
+    }
 
-    if (event?.type == "touchmove") {
+    if (event != null && event.type == "touchmove") {
       window.scrollBy(0, event.changedTouches[0].deltaY);
     }
 
     // remove obsolete event listeners
-    document.removeEventListener("touchstart", TouchEvent);
-    document.removeEventListener("wheel", WheelEvent);
+    document.removeEventListener("touchstart", removeSplashNav);
+    document.removeEventListener("wheel", removeSplashNav);
   }
 
   // homepage: scroll to about


### PR DESCRIPTION
The GitHub Action [website builder](https://github.com/facioquo/facioquo.com/actions/runs/9009361251/job/24753396764#step:7:19) uses some old Ruby Gems that require that our raw JavaScript is ES5 compatible.  I've also updated Ruby version from 3.1 to 3.2, which is probably all I really needed to do, but reverted the small ES6 items anyway; it builds okay on local with Ruby v3.2.2.

```bash
uglifier.rb:291:in `parse_result': Unexpected token: punc (.).
To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true). (Uglifier::Error)
```

I was able to use this nice little [JSHint.com](https://jshint.com) tool site to root out newer ES6+ syntax.