### PR TITLE
style(scss): Modernize color notation and fix stylelint warnings

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -36,7 +36,7 @@ img {
   text-decoration: none;
 }
 
-@media screen and (max-width: 480px) {
+@media (max-width: 480px) {
   .fq-button {
     display: block;
     margin: 2rem 0;
@@ -44,26 +44,22 @@ img {
 }
 
 .fq-button:hover {
-
   color: #c9c9c9;
-  background-color: rgba(35, 35, 35, 0.5);
+  background-color: rgb(35 35 35 / 50%);
   text-decoration: underline;
-
   box-shadow:
-    0px 10px 10px -3px rgba(86, 92, 101, 0.20),
-    0px 16px 20px 1px rgba(86, 92, 101, 0.14),
-    0px 6px 28px 2px rgba(86, 92, 101, 0.12);
+    0 10px 10px -3px rgb(86 92 101 / 20%),
+    0 16px 20px 1px rgb(86 92 101 / 14%),
+    0 6px 28px 2px rgb(86 92 101 / 12%);
 }
 
 .fq-button:active {
-
   color: #adadad;
-  background-color: rgba(86, 92, 101, 0.5);
-
+  background-color: rgb(86 92 101 / 50%);
   box-shadow:
-    0px 15px 15px -3px rgba(86, 92, 101, 0.20),
-    0px 24px 30px 1px rgba(86, 92, 101, 0.14),
-    0px 9px 40px 2px rgba(86, 92, 101, 0.12);
+    0 15px 15px -3px rgb(86 92 101 / 20%),
+    0 24px 30px 1px rgb(86 92 101 / 14%),
+    0 9px 40px 2px rgb(86 92 101 / 12%);
 }
 
 .fq-button:visited {


### PR DESCRIPTION
This pull request updates the button styling in the `_sass/_base.scss` file to use more modern CSS color syntax and simplifies media query usage. The changes focus on improving CSS readability and consistency.

Styling improvements:

* Updated color and box-shadow properties for `.fq-button:hover` and `.fq-button:active` to use the newer `rgb()` syntax with alpha transparency, replacing the older `rgba()` format for improved clarity and consistency.

CSS simplification:

* Removed redundant negative pixel values and simplified spacing in box-shadow definitions for button states.
* Changed the media query from `@media screen and (max-width: 480px)` to `@media (max-width: 480px)` for brevity and modern best practices.